### PR TITLE
Change how node is printed, so that attributes only affect individual node

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -155,9 +155,9 @@ func (g Graph) IndentedWrite(w *IndentWriter) {
 		w.NewLine()
 		// graph nodes
 		for _, each := range g.nodes {
-			fmt.Fprintf(w, "node")
+			fmt.Fprintf(w, "n%d", each.seq)
 			appendSortedMap(each.attributes, true, w)
-			fmt.Fprintf(w, " n%d;", each.seq)
+			fmt.Fprintf(w, ";")
 			w.NewLine()
 		}
 		// graph edges


### PR DESCRIPTION
Fixing #1 

For example, with this main function,
```golang
func main() {
	g := dot.NewGraph(dot.Directed)
	n2 := g.Node("testing a little").Box()
	n1 := g.Node("coding")

	g.Edge(n1, n2)
	g.Edge(n2, n1, "back").Attr("color", "red")

	fmt.Println(g.String())
}
```
The output will be, 

```
digraph  {
	
	n2[label="coding"];
	n1[label="testing a little",shape="box"];
	n2->n1;
	n1->n2[color="red",label="back"];
	
}
```

Which will be rendered as 

![test](https://user-images.githubusercontent.com/2823529/51287819-2d81dc80-19ae-11e9-9154-9a751fb23f50.png)

Instead of 

![test](https://user-images.githubusercontent.com/2823529/51287897-936e6400-19ae-11e9-8035-11fcf8db16f1.png)
