### PR TITLE
ci: add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+
+matrix:
+  include:
+    - go: "1.11.x"
+
+script:
+  - go test -v ./...
+
+env:
+  - GO111MODULE=on
+
+install: true


### PR DESCRIPTION
If you are interested in enabling CI, this would be the config for Travis. But first, you would need to enable it in the GitHub Marketplace for Open Source projects here: https://github.com/marketplace/travis-ci