### PR TITLE
Add support for HTML attributes.

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -1,5 +1,9 @@
 package dot
 
+// HTML renders the provided content as graphviz HTML. Use of this
+// type is only valid for some attributes, like the 'label' attribute.
+type HTML string
+
 // AttributesMap holds attribute=value pairs.
 type AttributesMap struct {
 	attributes map[string]interface{}

--- a/graph.go
+++ b/graph.go
@@ -221,7 +221,11 @@ func appendSortedMap(m map[string]interface{}, mustBracket bool, b io.Writer) {
 				fmt.Fprintf(b, ";")
 			}
 		}
-		fmt.Fprintf(b, "%s=%q", k, m[k])
+		if html, isHTML := m[k].(HTML); isHTML {
+			fmt.Fprintf(b, "%s=<%s>", k, html)
+		} else {
+			fmt.Fprintf(b, "%s=%q", k, m[k])
+		}
 		first = false
 	}
 	if mustBracket {

--- a/graph_test.go
+++ b/graph_test.go
@@ -25,6 +25,15 @@ func TestEmptyWithIDAndAttributes(t *testing.T) {
 	}
 }
 
+func TestEmptyWithHTMLLabel(t *testing.T) {
+	di := NewGraph(Directed)
+	di.ID("test")
+	di.Attr("label", HTML("<B>Hi</B>"))
+	if got, want := flatten(di.String()), `digraph test {ID = "test";label=<<B>Hi</B>>;}`; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+}
+
 func TestTwoConnectedNodes(t *testing.T) {
 	di := NewGraph(Directed)
 	n1 := di.Node("A")


### PR DESCRIPTION
Some attributes, like the `label` attribute, allow you to use [HTML](https://www.graphviz.org/doc/info/shapes.html#html) to style them. HTML strings are enclosed in angle brackets rather than quotes.

This PR implements support for this.