### PR TITLE
Allow setting same rank for a group of nodes

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -18,6 +18,7 @@ type Graph struct {
 	edgesFrom map[string][]Edge
 	subgraphs map[string]*Graph
 	parent    *Graph
+	sameRank  map[string][]Node
 }
 
 func NewGraph(options ...GraphOption) *Graph {
@@ -27,6 +28,7 @@ func NewGraph(options ...GraphOption) *Graph {
 		nodes:         map[string]Node{},
 		edgesFrom:     map[string][]Edge{},
 		subgraphs:     map[string]*Graph{},
+		sameRank:      map[string][]Node{},
 	}
 	for _, each := range options {
 		each.Apply(graph)
@@ -145,6 +147,11 @@ func commonParentOf(one *Graph, two *Graph) *Graph {
 	return one.Root()
 }
 
+// AddToSameRank adds the given nodes to the specified rank group, forcing them to be rendered in the same row
+func (g *Graph) AddToSameRank(group string, nodes ...Node) {
+	g.sameRank[group] = append(g.sameRank[group], nodes...)
+}
+
 // String returns the source in dot notation.
 func (g Graph) String() string {
 	b := new(bytes.Buffer)
@@ -193,6 +200,14 @@ func (g Graph) IndentedWrite(w *IndentWriter) {
 				fmt.Fprint(w, ";")
 				w.NewLine()
 			}
+		}
+		for _, nodes := range g.sameRank {
+			str := ""
+			for _, n := range nodes {
+				str += fmt.Sprintf("n%d;", n.seq)
+			}
+			fmt.Fprintf(w, "{rank=same; %s};", str)
+			w.NewLine()
 		}
 	})
 	fmt.Fprintf(w, "}")

--- a/graph_test.go
+++ b/graph_test.go
@@ -82,6 +82,19 @@ func TestEdgeLabel(t *testing.T) {
 	}
 }
 
+func TestSameRank(t *testing.T) {
+	di := NewGraph(Directed)
+	foo1 := di.Node("foo1")
+	foo2 := di.Node("foo2")
+	bar := di.Node("bar")
+	foo1.Edge(foo2)
+	foo1.Edge(bar)
+	di.AddToSameRank("top-row", foo1, foo2)
+	if got, want := flatten(di.String()), `digraph  {n3[label="bar"];n1[label="foo1"];n2[label="foo2"];n1->n2;n1->n3;{rank=same; n1;n2;};}`; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+}
+
 // dot -Tpng cluster.dot > cluster.png && open cluster.png
 func TestCluster(t *testing.T) {
 	di := NewGraph(Directed)


### PR DESCRIPTION
By including {rank=same; n1; n2; n3} in a dot file, it forces nodes n1,
n2 and n3 to be rendered in the same row.