### PR TITLE
Introduce Literal attribute type

### DIFF
--- a/attr.go
+++ b/attr.go
@@ -4,6 +4,15 @@ package dot
 // type is only valid for some attributes, like the 'label' attribute.
 type HTML string
 
+// Literal renders the provided value as is, without adding enclosing
+// quotes, escaping newlines, quotations marks or any other characters.
+// For example:
+//     node.Attr("label", Literal(`"left-justified text\l"`))
+// allows you to left-justify the label (due to the \l at the end).
+// The caller is responsible for enclosing the value in quotes and for
+// proper escaping of special characters.
+type Literal string
+
 // AttributesMap holds attribute=value pairs.
 type AttributesMap struct {
 	attributes map[string]interface{}

--- a/graph.go
+++ b/graph.go
@@ -223,6 +223,8 @@ func appendSortedMap(m map[string]interface{}, mustBracket bool, b io.Writer) {
 		}
 		if html, isHTML := m[k].(HTML); isHTML {
 			fmt.Fprintf(b, "%s=<%s>", k, html)
+		} else if literal, isLiteral := m[k].(Literal); isLiteral {
+			fmt.Fprintf(b, "%s=%s", k, literal)
 		} else {
 			fmt.Fprintf(b, "%s=%q", k, m[k])
 		}

--- a/graph_test.go
+++ b/graph_test.go
@@ -34,6 +34,15 @@ func TestEmptyWithHTMLLabel(t *testing.T) {
 	}
 }
 
+func TestEmptyWithLiteralValueLabel(t *testing.T) {
+	di := NewGraph(Directed)
+	di.ID("test")
+	di.Attr("label", Literal(`"left-justified text\l"`))
+	if got, want := flatten(di.String()), `digraph test {ID = "test";label="left-justified text\l";}`; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+}
+
 func TestTwoConnectedNodes(t *testing.T) {
 	di := NewGraph(Directed)
 	n1 := di.Node("A")


### PR DESCRIPTION
RawString allows clients to circumvent golang's escape logic.

Before this commit, it was impossible to left- or right-justify text, as
the escape sequences \l and \r were escaped to \\l and \\r by printf("%q").