### PR TITLE
add edge connection to specific port of node functionality

### DIFF
--- a/edge.go
+++ b/edge.go
@@ -3,8 +3,9 @@ package dot
 // Edge represents a graph edge between two Nodes.
 type Edge struct {
 	AttributesMap
-	graph    *Graph
-	from, to Node
+	graph            *Graph
+	from, to         Node
+	fromPort, toPort string
 }
 
 // Attr sets key=value and returns the Egde.

--- a/edge_test.go
+++ b/edge_test.go
@@ -41,6 +41,62 @@ func TestEdgeStyleHelpers(t *testing.T) {
 	}
 }
 
+func TestEdgeWithTwoPorts(t *testing.T) {
+	di := NewGraph(Directed)
+	n1 := di.Node("A")
+	n1.Attr("label", HTML("<table><tr><td port='port_a'>A</td></tr></table>"))
+	n2 := di.Node("B")
+	n2.Attr("label", HTML("<table><tr><td port='port_b'>B</td></tr></table>"))
+	di.EdgeWithPorts(n1, n2, "port_a", "port_b")
+
+	want := "digraph  {n1[label=<<table><tr><td port='port_a'>A</td></tr></table>>];n2[label=<<table><tr><td port='port_b'>B</td></tr></table>>];n1:port_a->n2:port_b;}"
+	if got, want := flatten(di.String()), want; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+}
+
+func TestEdgeWithNoPorts(t *testing.T) {
+	di := NewGraph(Directed)
+	n1 := di.Node("A")
+	n1.Attr("label", HTML("<table><tr><td>A</td></tr></table>"))
+	n2 := di.Node("B")
+	n2.Attr("label", HTML("<table><tr><td>B</td></tr></table>"))
+	di.EdgeWithPorts(n1, n2, "", "")
+
+	want := "digraph  {n1[label=<<table><tr><td>A</td></tr></table>>];n2[label=<<table><tr><td>B</td></tr></table>>];n1->n2;}"
+	if got, want := flatten(di.String()), want; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+}
+
+func TestEdgeWithFirstPort(t *testing.T) {
+	di := NewGraph(Directed)
+	n1 := di.Node("A")
+	n1.Attr("label", HTML("<table><tr><td port='port_a'>A</td></tr></table>"))
+	n2 := di.Node("B")
+	n2.Attr("label", HTML("<table><tr><td>B</td></tr></table>"))
+	di.EdgeWithPorts(n1, n2, "port_a", "")
+
+	want := "digraph  {n1[label=<<table><tr><td port='port_a'>A</td></tr></table>>];n2[label=<<table><tr><td>B</td></tr></table>>];n1:port_a->n2;}"
+	if got, want := flatten(di.String()), want; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+}
+
+func TestEdgeWithSecondPort(t *testing.T) {
+	di := NewGraph(Directed)
+	n1 := di.Node("A")
+	n1.Attr("label", HTML("<table><tr><td>A</td></tr></table>"))
+	n2 := di.Node("B")
+	n2.Attr("label", HTML("<table><tr><td port='port_b'>B</td></tr></table>"))
+	di.EdgeWithPorts(n1, n2, "", "port_b")
+
+	want := "digraph  {n1[label=<<table><tr><td>A</td></tr></table>>];n2[label=<<table><tr><td port='port_b'>B</td></tr></table>>];n1->n2:port_b;}"
+	if got, want := flatten(di.String()), want; got != want {
+		t.Errorf("got [%v] want [%v]", got, want)
+	}
+}
+
 func TestEdgeSetLabel(t *testing.T) {
 	di := NewGraph(Directed)
 	n1 := di.Node("A")

--- a/graph.go
+++ b/graph.go
@@ -191,10 +191,10 @@ func (g *Graph) EdgeWithPorts(fromNode, toNode Node, fromNodePort, toNodePort st
 		AttributesMap: AttributesMap{attributes: map[string]interface{}{}},
 		graph:         edgeOwner}
 	if fromNodePort != "" {
-		e.fromPort = ":" + fromNodePort
+		e.fromPort = fromNodePort
 	}
 	if toNodePort != "" {
-		e.toPort = ":" + toNodePort
+		e.toPort = toNodePort
 	}
 	if len(labels) > 0 {
 		e.Attr("label", strings.Join(labels, ","))
@@ -273,7 +273,15 @@ func (g Graph) IndentedWrite(w *IndentWriter) {
 		for _, each := range g.sortedEdgesFromKeys() {
 			all := g.edgesFrom[each]
 			for _, each := range all {
-				fmt.Fprintf(w, "n%d%s%sn%d%s", each.from.seq, each.fromPort, denoteEdge, each.to.seq, each.toPort)
+				fromPort := ""
+				if each.fromPort != "" {
+					fromPort = ":" + each.fromPort
+				}
+				toPort := ""
+				if each.toPort != "" {
+					toPort = ":" + each.toPort
+				}
+				fmt.Fprintf(w, "n%d%s%sn%d%s", each.from.seq, fromPort, denoteEdge, each.to.seq, toPort)
 				appendSortedMap(each.attributes, true, w)
 				fmt.Fprint(w, ";")
 				w.NewLine()

--- a/graph.go
+++ b/graph.go
@@ -174,6 +174,12 @@ func (g *Graph) DeleteNode(id string) bool {
 // Nodes can be have multiple edges to the same other node (or itself).
 // If one or more labels are given then the "label" attribute is set to the edge.
 func (g *Graph) Edge(fromNode, toNode Node, labels ...string) Edge {
+	return g.EdgeWithPorts(fromNode, toNode, "", "", labels...)
+}
+
+// EdgeWithPorts creates a new edge between two nodes with ports.
+// Other functionality are the same
+func (g *Graph) EdgeWithPorts(fromNode, toNode Node, fromNodePort, toNodePort string, labels ...string) Edge {
 	// assume fromNode owner == toNode owner
 	edgeOwner := g
 	if fromNode.graph != toNode.graph { // 1 or 2 are subgraphs
@@ -184,6 +190,12 @@ func (g *Graph) Edge(fromNode, toNode Node, labels ...string) Edge {
 		to:            toNode,
 		AttributesMap: AttributesMap{attributes: map[string]interface{}{}},
 		graph:         edgeOwner}
+	if fromNodePort != "" {
+		e.fromPort = ":" + fromNodePort
+	}
+	if toNodePort != "" {
+		e.toPort = ":" + toNodePort
+	}
 	if len(labels) > 0 {
 		e.Attr("label", strings.Join(labels, ","))
 	}
@@ -261,7 +273,7 @@ func (g Graph) IndentedWrite(w *IndentWriter) {
 		for _, each := range g.sortedEdgesFromKeys() {
 			all := g.edgesFrom[each]
 			for _, each := range all {
-				fmt.Fprintf(w, "n%d%sn%d", each.from.seq, denoteEdge, each.to.seq)
+				fmt.Fprintf(w, "n%d%s%sn%d%s", each.from.seq, each.fromPort, denoteEdge, each.to.seq, each.toPort)
 				appendSortedMap(each.attributes, true, w)
 				fmt.Fprint(w, ";")
 				w.NewLine()


### PR DESCRIPTION
Feature: as described in Graphviz examples here https://renenyffenegger.ch/notes/tools/Graphviz/examples/index we can connect edge to specific node port
But current module api are not able to do it

I added some code for enable this ability