### PR TITLE
Escape/quote mermaid labels

### DIFF
--- a/mermaid.go
+++ b/mermaid.go
@@ -2,6 +2,7 @@ package dot
 
 import (
 	"fmt"
+	"html"
 	"strings"
 )
 
@@ -37,6 +38,10 @@ func MermaidFlowchart(g *Graph, orientation int) string {
 	return diagram(g, "flowchart", orientation)
 }
 
+func escape(value string) string {
+	return fmt.Sprintf(`"%s"`, html.EscapeString(value))
+}
+
 func diagram(g *Graph, diagramType string, orientation int) string {
 	sb := new(strings.Builder)
 	sb.WriteString(diagramType)
@@ -65,7 +70,7 @@ func diagram(g *Graph, diagramType string, orientation int) string {
 		if label := each.GetAttr("label"); label != nil {
 			txt = label.(string)
 		}
-		fmt.Fprintf(sb, "\tn%d%s%s%s;\n", each.seq, nodeShape.open, txt, nodeShape.close)
+		fmt.Fprintf(sb, "\tn%d%s%s%s;\n", each.seq, nodeShape.open, escape(txt), nodeShape.close)
 		if style := each.GetAttr("style"); style != nil {
 			fmt.Fprintf(sb, "\tstyle n%d %s\n", each.seq, style.(string))
 		}
@@ -80,7 +85,7 @@ func diagram(g *Graph, diagramType string, orientation int) string {
 		all := g.edgesFrom[each]
 		for _, each := range all {
 			if label := each.GetAttr("label"); label != nil {
-				fmt.Fprintf(sb, "\tn%d%s|%s|n%d;\n", each.from.seq, denoteEdge, label.(string), each.to.seq)
+				fmt.Fprintf(sb, "\tn%d%s|%s|n%d;\n", each.from.seq, denoteEdge, escape(label.(string)), each.to.seq)
 			} else {
 				fmt.Fprintf(sb, "\tn%d%sn%d;\n", each.from.seq, denoteEdge, each.to.seq)
 			}

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -10,7 +10,7 @@ func TestMermaidSimple(t *testing.T) {
 	n2 := di.Node("e2").Attr("shape", MermaidShapeRound).Attr("style", "fill:#90EE90")
 	n1.Edge(n2, "what").Attr("x", "y")
 	out := flatten(MermaidGraph(di, MermaidTopDown))
-	if got, want := out, "graph TD;n1(E1);n2(e2);style n2 fill:#90EE90n1-->|what|n2;"; got != want {
+	if got, want := out, `graph TD;n1("E1");n2("e2");style n2 fill:#90EE90n1-->|"what"|n2;`; got != want {
 		t.Errorf("got [%v]:%T want [%v]:%T", got, got, want, want)
 	}
 }
@@ -54,7 +54,7 @@ func TestMermaidShapes(t *testing.T) {
 	di.Node("trapalt").Attr("shape", MermaidShapeTrapezoidAlt)
 	s := MermaidGraph(di, MermaidLeftToRight)
 	t.Log(s)
-	if got, want := flatten(s), `graph LR;n2>asym];n3((circ));n4[(cyl)];n5{rhom};n1(round);n6([stad]);n7[[sub]];n8[/trap\];n9[\trapalt/];`; got != want {
+	if got, want := flatten(s), `graph LR;n2>"asym"];n3(("circ"));n4[("cyl")];n5{"rhom"};n1("round");n6(["stad"]);n7[["sub"]];n8[/"trap"\];n9[\"trapalt"/];`; got != want {
 		t.Errorf("got [%v]:%T want [%v]:%T", got, got, want, want)
 	}
 }
@@ -64,7 +64,7 @@ func TestUndirectedMermaid(t *testing.T) {
 	un.Node("love").Edge(un.Node("happinez"))
 	s := MermaidFlowchart(un, MermaidLeftToRight)
 	t.Log(s)
-	if got, want := flatten(s), "flowchart LR;n2(happinez);n1(love);n1---n2;"; got != want {
+	if got, want := flatten(s), `flowchart LR;n2("happinez");n1("love");n1---n2;`; got != want {
 		t.Errorf("got [%v]:%T want [%v]:%T", got, got, want, want)
 	}
 }


### PR DESCRIPTION
If labels aren't quoted than any special character will cause issue loading into mermaid.  Seems we just need to html escape the string and surround it in quotes.