### PR TITLE
Fix lint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ HTML and Literal values
 	// edges
 	outside.Edge(insideFour).Edge(insideOne).Edge(insideTwo).Edge(insideThree).Edge(outside)
 
-See also `ext/Subsystem` type for creating composition hierchies.
+See also `ext/Subsystem` type for creating composition hierarchies.
 
 
 ## record example

--- a/attr.go
+++ b/attr.go
@@ -7,7 +7,9 @@ type HTML string
 // Literal renders the provided value as is, without adding enclosing
 // quotes, escaping newlines, quotations marks or any other characters.
 // For example:
-//     node.Attr("label", Literal(`"left-justified text\l"`))
+//
+//	node.Attr("label", Literal(`"left-justified text\l"`))
+//
 // allows you to left-justify the label (due to the \l at the end).
 // The caller is responsible for enclosing the value in quotes and for
 // proper escaping of special characters.

--- a/dotx/composite.go
+++ b/dotx/composite.go
@@ -19,7 +19,7 @@ type Connectable interface {
 const (
 	// SameGraph means that the composite graph will be a cluster within the graph.
 	SameGraph compositeGraphKind = iota
-	// ExternalGraph means the the composite graph will be exported on its own, linked by the node within the graph
+	// ExternalGraph means the composite graph will be exported on its own, linked by the node within the graph
 	ExternalGraph
 )
 
@@ -64,10 +64,10 @@ func (s *Composite) Attr(label string, value interface{}) dot.Node {
 // ExportName argument name will be used for the .dot export and the HREF link using svg
 // So if name = "my example" then export will create "my_example.dot" and the link will be "my_example.svg"
 func (s *Composite) ExportName(name string) {
-	href := strings.ReplaceAll(name, " ", "_") + ".svg"
-	dot := strings.ReplaceAll(name, " ", "_") + ".dot"
-	s.outerNode.Attr("href", href)
-	s.dotFilename = dot
+	hrefFile := strings.ReplaceAll(name, " ", "_") + ".svg"
+	dotFile := strings.ReplaceAll(name, " ", "_") + ".dot"
+	s.outerNode.Attr("href", hrefFile)
+	s.dotFilename = dotFile
 }
 
 // Input creates an edge.

--- a/edge.go
+++ b/edge.go
@@ -8,7 +8,7 @@ type Edge struct {
 	fromPort, toPort string
 }
 
-// Attr sets key=value and returns the Egde.
+// Attr sets key=value and returns the Edge.
 func (e Edge) Attr(key string, value interface{}) Edge {
 	e.AttributesMap.Attr(key, value)
 	return e

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/emicklei/dot
 
-go 1.13
+go 1.21.6

--- a/graph.go
+++ b/graph.go
@@ -192,7 +192,7 @@ func (g *Graph) DeleteNode(id string) bool {
 }
 
 // Edge creates a new edge between two nodes.
-// Nodes can be have multiple edges to the same other node (or itself).
+// Nodes can have multiple edges to the same other node (or itself).
 // If one or more labels are given then the "label" attribute is set to the edge.
 func (g *Graph) Edge(fromNode, toNode Node, labels ...string) Edge {
 	return g.EdgeWithPorts(fromNode, toNode, "", "", labels...)

--- a/indent.go
+++ b/indent.go
@@ -11,7 +11,7 @@ type IndentWriter struct {
 	writer io.Writer
 }
 
-// NewIndentWriter returna new IndentWriter with indent level 0.
+// NewIndentWriter returns a new IndentWriter with indent level 0.
 func NewIndentWriter(w io.Writer) *IndentWriter {
 	return &IndentWriter{level: 0, writer: w}
 }
@@ -27,7 +27,7 @@ func (i *IndentWriter) BackIndent() {
 	i.level--
 }
 
-// IndentWhile call the blocks after an indent and will restore that indent afterwards.
+// IndentWhile call the blocks after an indent and will restore that indent afterward.
 func (i *IndentWriter) IndentWhile(block func()) {
 	i.Indent()
 	block()

--- a/mermaid.go
+++ b/mermaid.go
@@ -19,6 +19,7 @@ var (
 	MermaidShapeStadium      = shape{"([", "])"}
 	MermaidShapeSubroutine   = shape{"[[", "]]"}
 	MermaidShapeCylinder     = shape{"[(", ")]"}
+	MermaidShapeCirle        = shape{"((", "))"} // Deprecated: use MermaidShapeCircle instead
 	MermaidShapeCircle       = shape{"((", "))"}
 	MermaidShapeAsymmetric   = shape{">", "]"}
 	MermaidShapeRhombus      = shape{"{", "}"}

--- a/mermaid.go
+++ b/mermaid.go
@@ -19,7 +19,7 @@ var (
 	MermaidShapeStadium      = shape{"([", "])"}
 	MermaidShapeSubroutine   = shape{"[[", "]]"}
 	MermaidShapeCylinder     = shape{"[(", ")]"}
-	MermaidShapeCirle        = shape{"((", "))"}
+	MermaidShapeCircle       = shape{"((", "))"}
 	MermaidShapeAsymmetric   = shape{">", "]"}
 	MermaidShapeRhombus      = shape{"{", "}"}
 	MermaidShapeTrapezoid    = shape{"[/", "\\]"}

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -59,6 +59,17 @@ func TestMermaidShapes(t *testing.T) {
 	}
 }
 
+// Deprecated: Use MermaidShapeCircle instead of MermaidShapeCirle
+func TestMermaidShapeCirle(t *testing.T) {
+	di := NewGraph(Directed)
+	di.Node("circ").Attr("shape", MermaidShapeCirle)
+	s := MermaidGraph(di, MermaidLeftToRight)
+	// t.Log(s)
+	if got, want := flatten(s), `graph LR;n1(("circ"));`; got != want {
+		t.Errorf("got [%v]:%T want [%v]:%T", got, got, want, want)
+	}
+}
+
 func TestUndirectedMermaid(t *testing.T) {
 	un := NewGraph(Undirected)
 	un.Node("love").Edge(un.Node("happinez"))

--- a/mermaid_test.go
+++ b/mermaid_test.go
@@ -45,7 +45,7 @@ func TestMermaidShapes(t *testing.T) {
 	di := NewGraph(Directed)
 	di.Node("round").Attr("shape", MermaidShapeRound)
 	di.Node("asym").Attr("shape", MermaidShapeAsymmetric)
-	di.Node("circ").Attr("shape", MermaidShapeCirle)
+	di.Node("circ").Attr("shape", MermaidShapeCircle)
 	di.Node("cyl").Attr("shape", MermaidShapeCylinder)
 	di.Node("rhom").Attr("shape", MermaidShapeRhombus)
 	di.Node("stad").Attr("shape", MermaidShapeStadium)


### PR DESCRIPTION
Mostly, fix some small typos.

Rename 'dot' to 'dotFile' since 'dot' shadows an imported package of the same name. Since we are renaming 'dot', also rename the corresponding 'href' variable so they are of consistent form.

Rename 'MermaidShapeCirle' to 'MermaidShapeCircle' as the former was likely a typo.

Verified by running 'go test ./...' and confirming all tests passed.